### PR TITLE
#54: LogProvider to list the categories that it holds

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,21 @@ var logs = logger.GetAllLogEntriesWithExceptions();
 
 ### TestCaptureLoggerProvider methods
 
+#### GetCategories()
+
+Gets all the logger categories created by this provider. NOTE: The category may not contain any logs. 
+
+```csharp
+// Arrange
+var logProvider = new TestCaptureLoggerProvider();
+
+// Act... Do something using the logProvider
+
+// Assert
+var categories = logProvider.GetCategories();
+// categories is a read only list of strings.
+```
+
 #### GetAllLogEntries()
 
 Gets all the LogEntry objects generated via this provider in sequential order.

--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -10,6 +10,7 @@ Date: ???
 
 - #52: TestCaptureLoggerProvider.GetAllLogEntries()
 - #53: TestCaptureLogger(Provider).Get(All)LogsWithExceptions()
+- #54: TestCaptureLoggerProvider.GetCategories()
 
 ### Miscellaneous
 

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestCaptureLoggerProviderTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestCaptureLoggerProviderTests.cs
@@ -49,5 +49,23 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             allLogsWithExceptions[1].OriginalMessage.ShouldBe("Four");
             allLogsWithExceptions[2].OriginalMessage.ShouldBe("Five");
         }
+        
+        [Test]
+        public void GetCategoriesReturnsListOfCategoryNames()
+        {
+            var provider = new TestCaptureLoggerProvider();
+            var factory = new LoggerFactory();
+            factory.AddProvider(provider);
+
+            provider.CreateLogger("logger1");
+            provider.CreateLogger("logger2");
+            factory.CreateLogger<TestCaptureLoggerTests>();
+            
+            var categories = provider.GetCategories();
+            categories.Count.ShouldBe(3);
+            categories.ShouldContain("logger1");
+            categories.ShouldContain("logger2");
+            categories.ShouldContain(typeof(TestCaptureLoggerTests).FullName);
+        }
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLoggerProvider.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLoggerProvider.cs
@@ -66,6 +66,15 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         }
 
         /// <summary>
+        /// Gets a list of log categories that were set up by this provider. 
+        /// </summary>
+        /// <returns>A read-only list of category names.</returns>
+        public IReadOnlyList<string> GetCategories()
+        {
+            return _captures.Keys.ToArray();
+        }
+        
+        /// <summary>
         /// Gets all log entries regardless of the Category they were logged as.
         /// </summary>
         /// <returns>A read only list of <see cref="LogEntry"/></returns>


### PR DESCRIPTION
TestCaptureLoggerProvider.GetCategories()