### PR TITLE
#56: Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ public void TestServiceLoggerCalled()
   service.DoStuff();
 
   // Assert
-  logger.Logs.Count.ShouldBe(1);
-  logger.Logs[0].FormattedMessage.ShouldContain("The work is done.");
+  var logs = logger.GetLogs();
+  logs.Count.ShouldBe(1);
+  logs[0].FormattedMessage.ShouldContain("The work is done.");
 }
 ```
 
@@ -128,9 +129,11 @@ var entries = logProvider.GetLogEntriesFor<T>();
 // Assert the entries from the logger.
 ```
 
-### What you get from the log entries
+### TestCaptureLogger methods
 
-The `TestCaptureLogger.Logs` allows you to retriece the logs within your test method. The property will be in sequence, timestamps will be incremental(*). Each `LogEntry` retrieved contains the following properties:
+### GetLogs()
+
+The `TestCaptureLogger.GetLogs()` allows you to retrieve the logs within your test method. The property will be in sequence, timestamps will be incremental(*). Each `LogEntry` retrieved contains the following properties:
 * `LogLevel` which is a `Microsoft.Extensions.Logging.LogLevel` enum.
 * `Exception` contains any exception that was passed into the logger.
 * `FormattedMessage` is the formatted message with the placeholders filled in.
@@ -141,9 +144,8 @@ The `TestCaptureLogger.Logs` allows you to retriece the logs within your test me
 
 (*) Timestamps will be incremental, but two logs created sufficiently close to one another in time may contain the same timestamp due to the resolution of the clock.
 
-### TestCaptureLogger methods
 
-#### GetLogEntriesWithExceptions
+#### GetLogEntriesWithExceptions()
 
 Gets all the log entries generated via this logger in sequential order that have exception objects attached to them.
 
@@ -157,9 +159,6 @@ var logger = new TestCaptureLogger();
 var logs = logger.GetAllLogEntriesWithExceptions();
 // logs is a read only list of LogEntry objects in sequential order.
 ```
-
-
-
 
 ### TestCaptureLoggerProvider methods
 

--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -11,6 +11,7 @@ Date: ???
 - #52: TestCaptureLoggerProvider.GetAllLogEntries()
 - #53: TestCaptureLogger(Provider).Get(All)LogsWithExceptions()
 - #54: TestCaptureLoggerProvider.GetCategories()
+- #56: TestCaptureLogger.GetLogs() (Logs property now marked as obsolete.)
 
 ### Miscellaneous
 

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
@@ -19,13 +19,14 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
                 messageTemplate,
                 whatAmIValue,
                 whatItHasValue);
-            
-            logger.Logs.Count.ShouldBe(1);
-            logger.Logs[0].Properties.ShouldNotBeNull();
-            logger.Logs[0].Properties.Count.ShouldBe(3);
-            logger.Logs[0].OriginalMessage.ShouldBe(messageTemplate);
-            logger.Logs[0].Properties[0].Key.ShouldBe("whatAmI");
-            logger.Logs[0].Properties[1].Key.ShouldBe("whatItHas");
+
+            var logs = logger.GetLogs();
+            logs.Count.ShouldBe(1);
+            logs[0].Properties.ShouldNotBeNull();
+            logs[0].Properties.Count.ShouldBe(3);
+            logs[0].OriginalMessage.ShouldBe(messageTemplate);
+            logs[0].Properties[0].Key.ShouldBe("whatAmI");
+            logs[0].Properties[1].Key.ShouldBe("whatItHas");
         }
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestUsingATypedLogger.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestUsingATypedLogger.cs
@@ -28,10 +28,11 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             var service = new MyServiceClass(logger);
             
             service.DoWork();
-            
-            logger.Logs.Count.ShouldBe(1);
-            logger.Logs[0].LogLevel.ShouldBe(LogLevel.Information);
-            logger.Logs[0].FormattedMessage.ShouldContain("Called DoWork()");
+
+            var logs = logger.GetLogs();
+            logs.Count.ShouldBe(1);
+            logs[0].LogLevel.ShouldBe(LogLevel.Information);
+            logs[0].FormattedMessage.ShouldContain("Called DoWork()");
         }
 
         [Test]

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestsUsingTheLoggerDirectly.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestsUsingTheLoggerDirectly.cs
@@ -26,7 +26,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             logger.LogInformation(message);
 
             // Assert
-            var logEntries = logger.Logs;
+            var logEntries = logger.GetLogs();
             logEntries.Count.ShouldBe(1);
             var entry = logEntries.First();
             entry.Exception.ShouldBeNull();
@@ -50,7 +50,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             logger.LogCritical("This is a critical message.");
     
             // Assert
-            var logEntries = logger.Logs;
+            var logEntries = logger.GetLogs();
             logEntries.Count.ShouldBe(6);
             logEntries[0].LogLevel.ShouldBe(LogLevel.Trace);
             logEntries[1].LogLevel.ShouldBe(LogLevel.Debug);
@@ -69,7 +69,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             // Act - none, no logs are being created.
             
             // Assert
-            var logEntries = logger.Logs;
+            var logEntries = logger.GetLogs();
             logEntries.Count.ShouldBe(0);
         }
 
@@ -82,7 +82,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             logger.LogInformation("Message 1");
             logger.LogInformation("Message 2");
 
-            var logEntries = logger.Logs;
+            var logEntries = logger.GetLogs();
             logEntries[0].Sequence.ShouldBeLessThan(logEntries[1].Sequence);
         }
 
@@ -96,7 +96,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             logger1.LogInformation("Message 1");
             logger2.LogInformation("Message 2");
 
-            logger1.Logs[0].Sequence.ShouldBeLessThan(logger2.Logs[0].Sequence);
+            logger1.GetLogs()[0].Sequence.ShouldBeLessThan(logger2.GetLogs()[0].Sequence);
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             Task.WaitAll(tasks, source.Token);
             
             tasks.ShouldAllBe(t => t.IsCompleted);
-            var logs = logger.Logs;
+            var logs = logger.GetLogs();
             logs.Count.ShouldBe(expectedLogCount);
             
             // Check no duplicate sequence numbers

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger.cs
@@ -28,18 +28,23 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         /// </summary>
         /// <remarks>Any additional logs added to the logger after this is
         /// called won't be available in the list and it will have to be called again.</remarks>
-        public IReadOnlyList<LogEntry> Logs
+        [Obsolete("This will be removed in v2.0. Use GetLogs() instead.")]
+        public IReadOnlyList<LogEntry> Logs => GetLogs();
+
+        /// <summary>
+        /// Gets a read-only list of logs that is a snapshot of this logger.
+        /// </summary>
+        /// <remarks>Any additional logs added to the logger after this is
+        /// called won't be available in the list and it will have to be called again.</remarks>
+        public IReadOnlyList<LogEntry> GetLogs()
         {
-            get
+            lock (_syncRoot)
             {
-                lock (_syncRoot)
-                {
-                    _logs.Sort();
-                    return _logs.ToArray();
-                }
+                _logs.Sort();
+                return _logs.ToArray();
             }
         }
-
+        
         /// <summary>
         /// Gets a read-only list of logs that have an exception attached in sequential order.
         /// </summary>

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLoggerProvider.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLoggerProvider.cs
@@ -30,7 +30,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         public IReadOnlyList<LogEntry> GetLogEntriesFor(string categoryName)
         {
             return _captures.TryGetValue(categoryName, out TestCaptureLogger logger)
-                ? logger.Logs
+                ? logger.GetLogs()
                 : Array.Empty<LogEntry>();
         }
 
@@ -81,7 +81,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         public IReadOnlyList<LogEntry> GetAllLogEntries()
         {
             var loggers = _captures.Values;
-            var allLogs = loggers.SelectMany(l => l.Logs).ToList();
+            var allLogs = loggers.SelectMany(l => l.GetLogs()).ToList();
             allLogs.Sort();
             return allLogs;
         }


### PR DESCRIPTION
Make getting the LogEntry objects from the TestCaptureLogger consistent with other extraction members. i.e. make it a method, not a property.