### PR TITLE
#60 Add a way to render logs in the test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: 
       - main
-      - "#60/render-logs"
 
     paths-ignore:
       - 'README.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: 
       - main
+      - "#60/render-logs"
 
     paths-ignore:
       - 'README.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - name: Set Time Zone to Europe/London
+        shell: pwsh
+        run: sudo timedatectl set-timezone "Europe/London"
+
       - name: Check out code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
        
       - name: Run Tests
         run: dotnet test src/Stravaig.Extensions.Logging.Diagnostics.Tests/Stravaig.Extensions.Logging.Diagnostics.Tests.csproj --configuration Release
-       
+
       - name: Package Preview Release
         if: ${{ env.STRAVAIG_IS_PREVIEW == 'true' }}
         run: dotnet pack ./src/Stravaig.Extensions.Logging.Diagnostics/Stravaig.Extensions.Logging.Diagnostics.csproj --configuration Release --output ./out --include-symbols --include-source /p:VersionPrefix="$STRAVAIG_PACKAGE_VERSION" --version-suffix "$STRAVAIG_PACKAGE_VERSION_SUFFIX" -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

--- a/README.md
+++ b/README.md
@@ -207,6 +207,29 @@ var logs = logProvider.GetAllLogEntriesWithExceptions();
 // logs is a read only list of LogEntry objects in sequential order.
 ```
 
+### IEnumerable<LogEntry>.RenderLogs()
+
+This is an extension method in the `Stravaig.Extensions.Logging.Diagnostics.Renderer` namespace.
+
+The implied object is an `IEnumerable<LogEntry>` so it will operate over any iterable collection of `LogEntry` objects.
+
+The method takes two parameters, a formatting function and a sink action. The formatting function takes the LogEntry and formats it into a string. The sink action takes the formatted string and writes it to some output mechanism such as the console, or a debug trace listener.
+
+e.g.
+
+```csharp
+logger.GetLogs()
+      .RenderLogs(
+          le => $"{le.Sequence}: {le.FormattedMessage}",
+          msg => Debug.WriteLine(msg));
+```
+
+There are some built in Formatters and Sinks to get started with.
+
+```csharp
+logger.GetLogs()
+      .RenderLogs(Formatter.SimpleBySequence, Sink.Console);
+```
 
 ### Example project
 

--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -8,6 +8,8 @@ Date: ???
 
 ### Features
 
+- #60: Add a log rendered.
+
 ### Miscellaneous
 
 - #74: Introduce support .NET 6.0

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/FormatterTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/FormatterTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Shouldly;
+using Stravaig.Extensions.Logging.Diagnostics.Render;
+
+namespace Stravaig.Extensions.Logging.Diagnostics.Tests.Renderer
+{
+    [TestFixture]
+    public class FormatterTests
+    {
+        [Test]
+        public void SequenceWithNoException()
+        {
+            var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
+                "This is the test log message.", 1, DateTime.UtcNow);
+
+            var renderedLog = Formatter.SimpleBySequence(logEntry);
+            
+            renderedLog.ShouldBe("[1 Information] This is the test log message.");
+        }
+
+        [Test]
+        public void UtcTimeWithNoException()
+        {
+            var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
+                "This is the test log message.", 1, DateTime.UnixEpoch);
+
+            var renderedLog = Formatter.SimpleByUtcTime(logEntry);
+            
+            renderedLog.ShouldBe("[1970-01-01T00:00:00+00:00 Information] This is the test log message.");
+        }
+        
+        [Test]
+        public void LocalTimeWithNoException()
+        {
+            var timestamp = new DateTimeOffset(2021, 06, 12, 13, 14, 15, TimeSpan.FromHours(01))
+                .UtcDateTime;
+            var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
+                "This is the test log message.", 1, timestamp);
+
+            var renderedLog = Formatter.SimpleByLocalTime(logEntry);
+            
+            renderedLog.ShouldBe("[2021-06-12T13:14:15+01:00 Information] This is the test log message.");
+        }
+    }
+}

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/FormatterTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/FormatterTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Shouldly;

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/LogEntryRendererExtensionsTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/LogEntryRendererExtensionsTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Shouldly;
+using Stravaig.Extensions.Logging.Diagnostics.Render;
+
+namespace Stravaig.Extensions.Logging.Diagnostics.Tests.Renderer
+{
+    [TestFixture]
+    public class LogEntryRendererExtensionsTests
+    {
+        [Test]
+        public void EmptyArray_RendersNothing()
+        {
+            int writeToSinkCount = 0;
+            int formatCount = 0;
+            
+            Array.Empty<LogEntry>().RenderLogs(_ => formatCount++.ToString(), _ => writeToSinkCount++);
+            
+            writeToSinkCount.ShouldBe(0);
+            formatCount.ShouldBe(0);
+        }
+
+        [Test]
+        public void SingleLog_RendersOneItem()
+        {
+            int writeToSinkCount = 0;
+            int formatCount = 0;
+
+            var logger = new TestCaptureLogger();
+            logger.LogInformation("Some log.");
+
+            logger.GetLogs()
+                .RenderLogs(le => $"{++formatCount} {le.FormattedMessage}", s =>
+                {
+                    writeToSinkCount++;
+                    s.ShouldBe("1 Some log.");
+                });
+            
+            writeToSinkCount.ShouldBe(1);
+            formatCount.ShouldBe(1);
+        }
+        
+        [Test]
+        public void ManyLogs_RendersItems()
+        {
+            int formatCount = 0;
+
+            var logger = new TestCaptureLogger();
+            logger.LogInformation("Some log.");
+            logger.LogInformation("Some other log.");
+            logger.LogInformation("A third log.");
+
+            List<string> sink = new List<string>();
+
+            logger.GetLogs()
+                .RenderLogs(
+                    le => $"{++formatCount} {le.FormattedMessage}",
+                    s => sink.Add(s));
+            
+            sink.Count.ShouldBe(3);
+            formatCount.ShouldBe(3);
+            
+            sink[0].ShouldBe("1 Some log.");
+            sink[1].ShouldBe("2 Some other log.");
+            sink[2].ShouldBe("3 A third log.");
+        }
+    }
+}

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/SinkTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/SinkTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Shouldly;
+using Stravaig.Extensions.Logging.Diagnostics.Render;
+
+namespace Stravaig.Extensions.Logging.Diagnostics.Tests.Renderer
+{
+    [TestFixture]
+    public class SinkTests
+    {
+        [Test]
+        public void ManyLogs_ConsoleSink()
+        {
+            var originalStream = Console.Out;
+            var sb = new StringBuilder();
+            try
+            {
+                using var writer = new StringWriter(sb);
+                Console.SetOut(writer);
+                var logger = new TestCaptureLogger();
+                logger.LogTrace("First log at the trace level.");
+                logger.LogDebug("Second log at the debug level.");
+                logger.LogInformation("Third log at the information level.");
+                logger.GetLogs()
+                    .RenderLogs(
+                        le => $"[{le.LogLevel}] {le.FormattedMessage}",
+                        Sink.Console);
+            }
+            finally
+            {
+                Console.SetOut(originalStream);
+            }
+
+            var consoleOutput = sb.ToString();
+            Console.WriteLine(consoleOutput);
+            var logLines = consoleOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            
+            logLines.Length.ShouldBe(3);
+            logLines[0].ShouldBe("[Trace] First log at the trace level.");
+            logLines[1].ShouldBe("[Debug] Second log at the debug level.");
+            logLines[2].ShouldBe("[Information] Third log at the information level.");
+        }
+        
+        [Test]
+        public void ManyLogs_DebugSink()
+        {
+            var sb = new StringBuilder();
+            using var writer = new StringWriter(sb);
+            var traceListener = new TextWriterTraceListener(writer);
+            try
+            {
+                Trace.Listeners.Add(traceListener);
+                var logger = new TestCaptureLogger();
+                logger.LogTrace("First log at the trace level.");
+                logger.LogDebug("Second log at the debug level.");
+                logger.LogInformation("Third log at the information level.");
+                logger.GetLogs()
+                    .RenderLogs(
+                        le => $"[{le.LogLevel}] {le.FormattedMessage}",
+                        Sink.Debug);
+            }
+            finally
+            {
+                traceListener.Flush();
+                Trace.Listeners.Remove(traceListener);
+            }
+
+            var consoleOutput = sb.ToString();
+            Console.WriteLine(consoleOutput);
+            var logLines = consoleOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            
+            logLines.Length.ShouldBe(3);
+            logLines[0].ShouldBe("[Trace] First log at the trace level.");
+            logLines[1].ShouldBe("[Debug] Second log at the debug level.");
+            logLines[2].ShouldBe("[Information] Third log at the information level.");
+        }
+    }
+}

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/SinkTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/SinkTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -33,40 +32,6 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests.Renderer
             finally
             {
                 Console.SetOut(originalStream);
-            }
-
-            var consoleOutput = sb.ToString();
-            Console.WriteLine(consoleOutput);
-            var logLines = consoleOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-            
-            logLines.Length.ShouldBe(3);
-            logLines[0].ShouldBe("[Trace] First log at the trace level.");
-            logLines[1].ShouldBe("[Debug] Second log at the debug level.");
-            logLines[2].ShouldBe("[Information] Third log at the information level.");
-        }
-        
-        [Test]
-        public void ManyLogs_DebugSink()
-        {
-            var sb = new StringBuilder();
-            using var writer = new StringWriter(sb);
-            var traceListener = new TextWriterTraceListener(writer);
-            try
-            {
-                Trace.Listeners.Add(traceListener);
-                var logger = new TestCaptureLogger();
-                logger.LogTrace("First log at the trace level.");
-                logger.LogDebug("Second log at the debug level.");
-                logger.LogInformation("Third log at the information level.");
-                logger.GetLogs()
-                    .RenderLogs(
-                        le => $"[{le.LogLevel}] {le.FormattedMessage}",
-                        Sink.Debug);
-            }
-            finally
-            {
-                traceListener.Flush();
-                Trace.Listeners.Remove(traceListener);
             }
 
             var consoleOutput = sb.ToString();

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Shouldly;
@@ -12,7 +11,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
         public void EnsureOriginalMessageAndPropertiesAreRetrievable()
         {
             var logger = new TestCaptureLogger();
-            var messageTemplate = "This is a {whatAmI} with {whatItHas}.";
+            const string messageTemplate = "This is a {whatAmI} with {whatItHas}.";
             var whatAmIValue = "message";
             var whatItHasValue = "structured parameters";
             logger.LogInformation(

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestsUsingALoggerFactory.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestsUsingALoggerFactory.cs
@@ -25,7 +25,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
                 builder.AddProvider(logProvider);
             });
             var logger = factory.CreateLogger<TestsUsingALoggerFactory>();
-            string message = "This is a test log message.";
+            const string message = "This is a test log message.";
             
             // Act
             logger.LogInformation(message);
@@ -100,7 +100,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
         {
             // Arrange
             var logProvider = new TestCaptureLoggerProvider();
-            var factory = LoggerFactory.Create(builder =>
+            LoggerFactory.Create(builder =>
             {
                 builder.AddProvider(logProvider);
             });
@@ -134,7 +134,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
                     {
                         var logger = provider.CreateLogger(categoryName);
                         logger.LogInformation(
-                            "Log iteration {iteration} on thread {threadId}",
+                            "Log iteration {Iteration} on thread {ThreadId}",
                             i,
                             Thread.CurrentThread.ManagedThreadId);
                     }

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestsUsingTheLoggerDirectly.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestsUsingTheLoggerDirectly.cs
@@ -20,7 +20,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
         {
             // Arrange
             var logger = new TestCaptureLogger();
-            string message = "This is a test log message.";
+            const string message = "This is a test log message.";
             
             // Act
             logger.LogInformation(message);
@@ -117,7 +117,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
                     for (int i = 0; i < iterationsPerThread; i++)
                     {
                         logger.LogInformation(
-                            "Log iteration {iteration} on thread {threadId}",
+                            "Log iteration {Iteration} on thread {ThreadId}",
                             i,
                             Thread.CurrentThread.ManagedThreadId);
                     }

--- a/src/Stravaig.Extensions.Logging.Diagnostics.sln.DotSettings
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/RunLongAnalysisInSwa/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/SweaWarningsMode/@EntryValue">ShowAndRun</s:String></wpf:ResourceDictionary>

--- a/src/Stravaig.Extensions.Logging.Diagnostics/AssemblyInfo.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Stravaig.Extensions.Logging.Diagnostics.Tests")]

--- a/src/Stravaig.Extensions.Logging.Diagnostics/ExternalHelpers/TypeNameHelper.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/ExternalHelpers/TypeNameHelper.cs
@@ -42,7 +42,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.ExternalHelpers
     {
         private const char DefaultNestedTypeDelimiter = '+';
 
-        private static readonly Dictionary<Type, string> _builtInTypeNames = new Dictionary<Type, string>
+        private static readonly Dictionary<Type, string> BuiltInTypeNames = new Dictionary<Type, string>
         {
             { typeof(void), "void" },
             { typeof(bool), "bool" },
@@ -94,7 +94,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.ExternalHelpers
             {
                 ProcessArrayType(builder, type, options);
             }
-            else if (_builtInTypeNames.TryGetValue(type, out string builtInName))
+            else if (BuiltInTypeNames.TryGetValue(type, out string builtInName))
             {
                 builder.Append(builtInName);
             }

--- a/src/Stravaig.Extensions.Logging.Diagnostics/LogEntry.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/LogEntry.cs
@@ -12,7 +12,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
     [DebuggerDisplay("{" + nameof(DebuggerDisplayString) + "}")]
     public class LogEntry : IComparable<LogEntry>
     {
-        private static int _sequence = 0;
+        private static int _sequence;
         private static readonly object SequenceSyncLock = new object();
 
         private const string OriginalMessagePropertyName = "{OriginalFormat}";

--- a/src/Stravaig.Extensions.Logging.Diagnostics/LogEntry.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/LogEntry.cs
@@ -101,6 +101,17 @@ namespace Stravaig.Extensions.Logging.Diagnostics
             }
         }
 
+        internal LogEntry(LogLevel logLevel, EventId eventId, object state, Exception exception, string formattedMessage, int sequence, DateTime timestampUtc)
+        {
+            LogLevel = logLevel;
+            EventId = eventId;
+            State = state;
+            Exception = exception;
+            FormattedMessage = formattedMessage;
+            Sequence = sequence;
+            TimestampUtc = timestampUtc;
+        }
+
         /// <inheritdoc />
         public int CompareTo(LogEntry other)
         {

--- a/src/Stravaig.Extensions.Logging.Diagnostics/Render/Formatter.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/Render/Formatter.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Stravaig.Extensions.Logging.Diagnostics.Render
+{
+    /// <summary>
+    /// Functions that format the log entries in specific ways
+    /// </summary>
+    public static class Formatter
+    {
+        /// <summary>
+        /// Formats the log entry as '[sequence level] message exception'
+        /// </summary>
+        public static Func<LogEntry, string> SimpleBySequence =>
+            le => $"[{le.Sequence} {le.LogLevel}] {le.FormattedMessage}{FormatAppendedException(le)}";
+        
+        /// <summary>
+        /// Formats the log entry as '[local-timestamp level] message exception'
+        /// </summary>
+        public static Func<LogEntry, string> SimpleByLocalTime =>
+            le => $"[{le.TimestampLocal:yyyy-MM-dd'T'HH:mm:sszzz} {le.LogLevel}] {le.FormattedMessage}{FormatAppendedException(le)}";
+
+        /// <summary>
+        /// Formats the log entry as '[utc-timestamp level] message exception'
+        /// </summary>
+        public static Func<LogEntry, string> SimpleByUtcTime =>
+            le => $"[{le.TimestampUtc:yyyy-MM-dd'T'HH:mm:sszzz} {le.LogLevel}] {le.FormattedMessage}{FormatAppendedException(le)}";
+        
+        private static string FormatAppendedException(LogEntry le)
+        {
+            return le.Exception == null
+                ? string.Empty
+                : $"{Environment.NewLine}{le.Exception}";
+        }
+    }
+}

--- a/src/Stravaig.Extensions.Logging.Diagnostics/Render/LogEntryRendererExtensions.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/Render/LogEntryRendererExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace Stravaig.Extensions.Logging.Diagnostics.Render
+{
+    /// <summary>
+    /// Extension methods for rendering logs
+    /// </summary>
+    public static class LogEntryRendererExtensions
+    {
+        /// <summary>
+        /// Renders a log to a sink with a given format.
+        /// </summary>
+        /// <param name="logs">The logs to render.</param>
+        /// <param name="format">The function that formats the log.</param>
+        /// <param name="writeToSink">The action that writes the formatted log to the sink.</param>
+        public static void RenderLogs(this IEnumerable<LogEntry> logs, Func<LogEntry, string> format, Action<string> writeToSink)
+        {
+            foreach (var log in logs)
+            {
+                var formatted = format(log);
+                writeToSink(formatted);
+            }
+        }
+    }
+}

--- a/src/Stravaig.Extensions.Logging.Diagnostics/Render/Sink.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/Render/Sink.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Stravaig.Extensions.Logging.Diagnostics.Render
+{
+    /// <summary>
+    /// Basic sinks for writing captured log entries.
+    /// </summary>
+    public static class Sink
+    {
+        /// <summary>
+        /// A console sink for the log renderer.
+        /// </summary>
+        public static Action<string> Console => System.Console.WriteLine;
+
+        /// <summary>
+        /// A debugger output sink for the log renderer.
+        /// </summary>
+        public static Action<string> Debug => s => System.Diagnostics.Debug.WriteLine(s);
+    }
+}

--- a/src/Stravaig.Extensions.Logging.Diagnostics/Render/Sink.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/Render/Sink.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Text;
 
 namespace Stravaig.Extensions.Logging.Diagnostics.Render
 {

--- a/src/Stravaig.Extensions.Logging.Diagnostics/Render/Sink.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/Render/Sink.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using System.Text;
 
 namespace Stravaig.Extensions.Logging.Diagnostics.Render
 {
@@ -13,10 +11,5 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Render
         /// A console sink for the log renderer.
         /// </summary>
         public static Action<string> Console => System.Console.WriteLine;
-
-        /// <summary>
-        /// A debugger output sink for the log renderer.
-        /// </summary>
-        public static Action<string> Debug => s => System.Diagnostics.Debug.WriteLine(s);
     }
 }


### PR DESCRIPTION
# Add a log renderer

## Issue

This PR addresses Issue #60.

Sometimes it is necessary to render logs in to the test output to help diagnose issues. This adds a renderer to make this easier.

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [x] I have updated the `readme.md` file
- [x] I have bumped the version number in the `version.txt`
- [x] I have added or updated any necessary tests.
- [x] I have ensured that any new code is covered by tests where reasonably possible.