### PR TITLE
#82 Add log source to the LogEntry object

### DIFF
--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -9,6 +9,7 @@ Date: ???
 ### Features
 
 - #60: Add a log rendered.
+- #82: Category Name is recorded in the log entry.
 
 ### Miscellaneous
 

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/CategoryNameTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/CategoryNameTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Stravaig.Extensions.Logging.Diagnostics.Tests
+{
+    [TestFixture]
+    public class CategoryNameTests
+    {
+        [Test]
+        public void Ctor()
+        {
+            var logEntry = new LogEntry(LogLevel.Information, new EventId(1), new object(), null, "Some message",
+                "Some category");
+            logEntry.CategoryName.ShouldBe("Some category");
+        }
+
+        [Test]
+        public void FromBasicLogger()
+        {
+            var logger = new TestCaptureLogger();
+            logger.LogInformation("Some log");
+            logger.GetLogs()[0].CategoryName.ShouldBe(string.Empty);
+        }
+
+        [Test]
+        public void FromBasicLoggerWithCategoryName()
+        {
+            var logger = new TestCaptureLogger("SomeCategory");
+            logger.LogInformation("Some log");
+            logger.GetLogs()[0].CategoryName.ShouldBe("SomeCategory");
+        }
+
+        [Test]
+        public void FromGenericLogger()
+        {
+            var logger = new TestCaptureLogger<CategoryNameTests>();
+            logger.LogInformation("Some log");
+            logger.GetLogs()[0].CategoryName.ShouldBe(typeof(CategoryNameTests).FullName);
+        }
+
+        [Test]
+        public void FromLogProvider()
+        {
+            var logProvider = new TestCaptureLoggerProvider();
+            var logger = logProvider.CreateLogger("SomeCategory");
+            logger.LogInformation("Some log");
+            logProvider.GetAllLogEntries()[0].CategoryName.ShouldBe("SomeCategory");
+        }
+    }
+}

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/FormatterTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/Renderer/FormatterTests.cs
@@ -13,7 +13,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests.Renderer
         public void SequenceWithNoException()
         {
             var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
-                "This is the test log message.", 1, DateTime.UtcNow);
+                "This is the test log message.", string.Empty, 1, DateTime.UtcNow);
 
             var renderedLog = Formatter.SimpleBySequence(logEntry);
             
@@ -21,14 +21,36 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests.Renderer
         }
 
         [Test]
+        public void SequenceWithCategoryNameAndNoException()
+        {
+            var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
+                "This is the test log message.", nameof(FormatterTests), 1, DateTime.UtcNow);
+
+            var renderedLog = Formatter.SimpleBySequence(logEntry);
+            
+            renderedLog.ShouldBe("[1 Information FormatterTests] This is the test log message.");
+        }
+
+        [Test]
         public void UtcTimeWithNoException()
         {
             var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
-                "This is the test log message.", 1, DateTime.UnixEpoch);
+                "This is the test log message.", string.Empty, 1, DateTime.UnixEpoch);
 
             var renderedLog = Formatter.SimpleByUtcTime(logEntry);
             
             renderedLog.ShouldBe("[1970-01-01T00:00:00+00:00 Information] This is the test log message.");
+        }
+
+        [Test]
+        public void UtcTimeWithCategoryNameAndNoException()
+        {
+            var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
+                "This is the test log message.", nameof(FormatterTests), 1, DateTime.UnixEpoch);
+
+            var renderedLog = Formatter.SimpleByUtcTime(logEntry);
+            
+            renderedLog.ShouldBe("[1970-01-01T00:00:00+00:00 Information FormatterTests] This is the test log message.");
         }
         
         [Test]
@@ -37,11 +59,24 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests.Renderer
             var timestamp = new DateTimeOffset(2021, 06, 12, 13, 14, 15, TimeSpan.FromHours(01))
                 .UtcDateTime;
             var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
-                "This is the test log message.", 1, timestamp);
+                "This is the test log message.", string.Empty, 1, timestamp);
 
             var renderedLog = Formatter.SimpleByLocalTime(logEntry);
             
             renderedLog.ShouldBe("[2021-06-12T13:14:15+01:00 Information] This is the test log message.");
+        }
+        
+        [Test]
+        public void LocalTimeWithCategoryNameAndNoException()
+        {
+            var timestamp = new DateTimeOffset(2021, 06, 12, 13, 14, 15, TimeSpan.FromHours(01))
+                .UtcDateTime;
+            var logEntry = new LogEntry(LogLevel.Information, new EventId(), null, null,
+                "This is the test log message.", nameof(FormatterTests), 1, timestamp);
+
+            var renderedLog = Formatter.SimpleByLocalTime(logEntry);
+            
+            renderedLog.ShouldBe("[2021-06-12T13:14:15+01:00 Information FormatterTests] This is the test log message.");
         }
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
@@ -21,11 +21,13 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
 
             var logs = logger.GetLogs();
             logs.Count.ShouldBe(1);
-            logs[0].Properties.ShouldNotBeNull();
-            logs[0].Properties.Count.ShouldBe(3);
-            logs[0].OriginalMessage.ShouldBe(messageTemplate);
-            logs[0].Properties[0].Key.ShouldBe("whatAmI");
-            logs[0].Properties[1].Key.ShouldBe("whatItHas");
+            var logEntry = logs[0];
+            logEntry.Properties.ShouldNotBeNull();
+            logEntry.Properties.Count.ShouldBe(3);
+            logEntry.OriginalMessage.ShouldBe(messageTemplate);
+            logEntry.Properties[0].Key.ShouldBe("whatAmI");
+            logEntry.Properties[1].Key.ShouldBe("whatItHas");
+            logEntry.CategoryName.ShouldBe(string.Empty);
         }
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics.sln.DotSettings
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.sln.DotSettings
@@ -1,3 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/RunLongAnalysisInSwa/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/RunLongAnalysisInSwa/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/SweaWarningsMode/@EntryValue">ShowAndRun</s:String></wpf:ResourceDictionary>

--- a/src/Stravaig.Extensions.Logging.Diagnostics/LogEntry.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/LogEntry.cs
@@ -78,7 +78,12 @@ namespace Stravaig.Extensions.Logging.Diagnostics
             (string) Properties
                 .FirstOrDefault(p => p.Key == OriginalMessagePropertyName)
                 .Value;
-
+        
+        /// <summary>
+        /// The category name of the log entry, if available.
+        /// </summary>
+        public string CategoryName { get; }
+        
         /// <summary>
         /// Initialises a <see cref="T:Stravaig.Extensions.Logging.Diagnostics.LogEntry"/>.
         /// </summary>
@@ -87,6 +92,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         /// <param name="state">The entry that was written. Can be also an object.</param>
         /// <param name="exception">The <see cref="T:System.Exception"/> that was attached to the log.</param>
         /// <param name="formattedMessage">The formatted message.</param>
+        [Obsolete("This will be removed in v2.0; use the constructor with the categoryName parameter.")]
         public LogEntry(LogLevel logLevel, EventId eventId, object state, Exception exception, string formattedMessage)
         {
             LogLevel = logLevel;
@@ -101,7 +107,31 @@ namespace Stravaig.Extensions.Logging.Diagnostics
             }
         }
 
-        internal LogEntry(LogLevel logLevel, EventId eventId, object state, Exception exception, string formattedMessage, int sequence, DateTime timestampUtc)
+        /// <summary>
+        /// Initialises a <see cref="T:Stravaig.Extensions.Logging.Diagnostics.LogEntry"/>.
+        /// </summary>
+        /// <param name="logLevel">The <see cref="T:Microsoft.Extensions.Logging.LogLeve"/> that was logged.</param>
+        /// <param name="eventId">An <see cref="T:Microsoft.Extensions.Logging.EventId"/> that identifies the logging event.</param>
+        /// <param name="state">The entry that was written. Can be also an object.</param>
+        /// <param name="exception">The <see cref="T:System.Exception"/> that was attached to the log.</param>
+        /// <param name="formattedMessage">The formatted message.</param>
+        /// <param name="categoryName">The source or category name.</param>
+        public LogEntry(LogLevel logLevel, EventId eventId, object state, Exception exception, string formattedMessage, string categoryName)
+        {
+            LogLevel = logLevel;
+            EventId = eventId;
+            State = state;
+            Exception = exception;
+            FormattedMessage = formattedMessage;
+            lock (SequenceSyncLock)
+            {
+                Sequence = _sequence++;
+                TimestampUtc = DateTime.UtcNow;
+            }
+            CategoryName = categoryName;
+        }
+
+        internal LogEntry(LogLevel logLevel, EventId eventId, object state, Exception exception, string formattedMessage, string categoryName, int sequence, DateTime timestampUtc)
         {
             LogLevel = logLevel;
             EventId = eventId;
@@ -110,6 +140,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
             FormattedMessage = formattedMessage;
             Sequence = sequence;
             TimestampUtc = timestampUtc;
+            CategoryName = categoryName;
         }
 
         /// <inheritdoc />
@@ -120,6 +151,6 @@ namespace Stravaig.Extensions.Logging.Diagnostics
             return Sequence.CompareTo(other.Sequence);
         }
 
-        private string DebuggerDisplayString => $"[#{Sequence} @ {TimestampLocal:HH:mm:ss.fff zzz} {LogLevel}] {FormattedMessage}";
+        private string DebuggerDisplayString => $"[#{Sequence} @ {TimestampLocal:HH:mm:ss.fff zzz} {LogLevel} {CategoryName}] {FormattedMessage}";
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics/Render/Formatter.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/Render/Formatter.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Globalization;
+using System.Text;
 
 namespace Stravaig.Extensions.Logging.Diagnostics.Render
 {
@@ -11,25 +13,33 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Render
         /// Formats the log entry as '[sequence level] message exception'
         /// </summary>
         public static Func<LogEntry, string> SimpleBySequence =>
-            le => $"[{le.Sequence} {le.LogLevel}] {le.FormattedMessage}{FormatAppendedException(le)}";
+            le => $"[{le.Sequence} {le.LogLevel}{FormatCategoryName(le)}] {le.FormattedMessage}{FormatAppendedException(le)}";
         
         /// <summary>
         /// Formats the log entry as '[local-timestamp level] message exception'
         /// </summary>
         public static Func<LogEntry, string> SimpleByLocalTime =>
-            le => $"[{le.TimestampLocal:yyyy-MM-dd'T'HH:mm:sszzz} {le.LogLevel}] {le.FormattedMessage}{FormatAppendedException(le)}";
+            le => $"[{le.TimestampLocal:yyyy-MM-dd'T'HH:mm:sszzz} {le.LogLevel}{FormatCategoryName(le)}] {le.FormattedMessage}{FormatAppendedException(le)}";
 
         /// <summary>
         /// Formats the log entry as '[utc-timestamp level] message exception'
         /// </summary>
         public static Func<LogEntry, string> SimpleByUtcTime =>
-            le => $"[{le.TimestampUtc:yyyy-MM-dd'T'HH:mm:sszzz} {le.LogLevel}] {le.FormattedMessage}{FormatAppendedException(le)}";
-        
+            le => $"[{le.TimestampUtc:yyyy-MM-dd'T'HH:mm:sszzz} {le.LogLevel}{FormatCategoryName(le)}] {le.FormattedMessage}{FormatAppendedException(le)}";
+
         private static string FormatAppendedException(LogEntry le)
         {
             return le.Exception == null
                 ? string.Empty
                 : $"{Environment.NewLine}{le.Exception}";
+        }
+
+        private static string FormatCategoryName(LogEntry le)
+        {
+            if (string.IsNullOrWhiteSpace(le.CategoryName))
+                return string.Empty;
+
+            return $" {le.CategoryName}";
         }
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger(OfTCategoryType).cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger(OfTCategoryType).cs
@@ -1,4 +1,6 @@
+using System;
 using Microsoft.Extensions.Logging;
+using Stravaig.Extensions.Logging.Diagnostics.ExternalHelpers;
 
 namespace Stravaig.Extensions.Logging.Diagnostics
 {
@@ -10,5 +12,12 @@ namespace Stravaig.Extensions.Logging.Diagnostics
     public class TestCaptureLogger<TCategoryType>
         : TestCaptureLogger, ILogger<TCategoryType>
     {
+        /// <summary>
+        /// Initialises a new instance of the <see cref="T:Stravaig.Extensions.Logging.Diagnostics.TestCaptureLogger&lt;TCategoryType>"/> class.
+        /// </summary>
+        public TestCaptureLogger()
+            : base(TypeNameHelper.GetTypeDisplayName(typeof(TCategoryType)))
+        {
+        }
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger.cs
@@ -21,8 +21,21 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         {
             _logs = new List<LogEntry>();
             _syncRoot = new object();
+            CategoryName = string.Empty;
         }
 
+        /// <summary>
+        /// Initialises a new instance of the TestCaptureLogger class.
+        /// </summary>
+        /// <param name="categoryName">The name of the category</param>
+        public TestCaptureLogger(string categoryName)
+            : this()
+        {
+            CategoryName = categoryName;
+        }
+
+        public string CategoryName { get; }
+        
         /// <summary>
         /// Gets a read-only list of logs that is a snapshot of this logger.
         /// </summary>
@@ -71,11 +84,26 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             var formattedMessage = formatter(state, exception);
-            var logEntry = new LogEntry(logLevel, eventId, state, exception, formattedMessage);
+            var logEntry = CreateLogEntry(logLevel, eventId, state, exception, formattedMessage);
             lock (_syncRoot)
             {
                 _logs.Add(logEntry);
             }
+        }
+
+        /// <summary>
+        /// Creates the LogEntry object.
+        /// </summary>
+        /// <param name="logLevel">The level the entry is logged at</param>
+        /// <param name="eventId">The event id</param>
+        /// <param name="state">The state (properties) of the log entry</param>
+        /// <param name="exception">Any exception</param>
+        /// <param name="formattedMessage">The formatted message</param>
+        /// <typeparam name="TState">The object type that holds the state</typeparam>
+        /// <returns>A log entry</returns>
+        protected LogEntry CreateLogEntry<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, string formattedMessage)
+        {
+            return new LogEntry(logLevel, eventId, state, exception, formattedMessage, CategoryName);
         }
 
         /// <summary>

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLoggerProvider.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLoggerProvider.cs
@@ -62,7 +62,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         /// <returns>The instance of ILogger that was created.</returns>
         public ILogger CreateLogger(string categoryName)
         {
-            return _captures.GetOrAdd(categoryName, _ => new TestCaptureLogger());
+            return _captures.GetOrAdd(categoryName, _ => new TestCaptureLogger(categoryName));
         }
 
         /// <summary>


### PR DESCRIPTION
# Record Category Name in the LogEntry

## Issue

This PR addresses Issue #82.

When examining the logs in a test it can be difficult to tell where a log came from if lots of categories are brought together in one list. Record the source/category name into the `LogEntry` so that tests can check where individual log entries come from.

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [ ] I have updated the `readme.md` file
- [ ] I have bumped the version number in the `version.txt`
- [ ] I have added or updated any necessary tests.
- [ ] I have ensured that any new code is covered by tests where reasonably possible.