### PR TITLE
#89 Add PropertyDictionary to make it easier to access properties

### DIFF
--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -10,6 +10,7 @@ Date: ???
 
 - #60: Add a log rendered.
 - #82: Category Name is recorded in the log entry.
+- #89: The log entry exposes the properties as an `IReadOnlyDictionary`
 
 ### Miscellaneous
 
@@ -21,10 +22,11 @@ Date: ???
 ### Dependencies
 
 - All targets:
+  - Bump NUnit3TestAdapter from 4.2.0 to 4.2.1
 - .NET Standard 2.0 targets:
   - Bump Microsoft.Extensions.Logging to 3.1.22
   - Bump Microsoft.Extensions.Logging.Abstractions to 3.1.22
-- .NET 5.0 targets:
+- .NET 5.0 targets: No change
 - .NET 6.0 targets:
   - Microsoft.Extensions.Logging to 6.0.0
   - Microsoft.Extensions.Logging.Abstractions to 6.0.0

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Shouldly;
@@ -28,6 +29,8 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
             logEntry.Properties[0].Key.ShouldBe("whatAmI");
             logEntry.Properties[1].Key.ShouldBe("whatItHas");
             logEntry.CategoryName.ShouldBe(string.Empty);
+            logEntry.PropertyDictionary["whatAmI"].ShouldBe(whatAmIValue);
+            logEntry.PropertyDictionary["whatItHas"].ShouldBe(whatItHasValue);
         }
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/StructuredLoggingTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Shouldly;

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestsUsingTheLoggerDirectly.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestsUsingTheLoggerDirectly.cs
@@ -148,6 +148,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics.Tests
 
             DateTime first = logs.First().TimestampUtc;
             DateTime last = logs.Last().TimestampUtc;
+            first.ShouldBeLessThanOrEqualTo(last);
             Console.WriteLine($"Logging started at {first:HH:mm:ss.fff} and ended at {last:HH:mm:ss.fff} taking a total of {(last-first):G}");
         }
     }

--- a/src/Stravaig.Extensions.Logging.Diagnostics/LogEntry.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/LogEntry.cs
@@ -16,6 +16,9 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         private static readonly object SequenceSyncLock = new object();
 
         private const string OriginalMessagePropertyName = "{OriginalFormat}";
+        
+        private Lazy<IReadOnlyDictionary<string, object>> _lazyPropertyDictionary;
+        
         /// <summary>
         /// The <see cref="T:Microsoft.Extensions.Logging.LogLevel"/> that the item was logged at.
         /// </summary>
@@ -70,6 +73,11 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         /// </summary>
         public IReadOnlyList<KeyValuePair<string, object>> Properties =>
             State as IReadOnlyList<KeyValuePair<string, object>> ?? Array.Empty<KeyValuePair<string, object>>();
+        
+        /// <summary>
+        /// The properties, if any, for the log entry.
+        /// </summary>
+        public IReadOnlyDictionary<string, object> PropertyDictionary => _lazyPropertyDictionary.Value;
 
         /// <summary>
         /// The original message template, if available, for the log entry.
@@ -83,6 +91,14 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         /// The category name of the log entry, if available.
         /// </summary>
         public string CategoryName { get; }
+
+        private LogEntry()
+        {
+            _lazyPropertyDictionary =
+                new Lazy<IReadOnlyDictionary<string, object>>(() => Properties.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value));
+        }
         
         /// <summary>
         /// Initialises a <see cref="T:Stravaig.Extensions.Logging.Diagnostics.LogEntry"/>.
@@ -94,6 +110,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         /// <param name="formattedMessage">The formatted message.</param>
         [Obsolete("This will be removed in v2.0; use the constructor with the categoryName parameter.")]
         public LogEntry(LogLevel logLevel, EventId eventId, object state, Exception exception, string formattedMessage)
+            : this()
         {
             LogLevel = logLevel;
             EventId = eventId;
@@ -117,6 +134,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         /// <param name="formattedMessage">The formatted message.</param>
         /// <param name="categoryName">The source or category name.</param>
         public LogEntry(LogLevel logLevel, EventId eventId, object state, Exception exception, string formattedMessage, string categoryName)
+            : this()
         {
             LogLevel = logLevel;
             EventId = eventId;
@@ -132,6 +150,7 @@ namespace Stravaig.Extensions.Logging.Diagnostics
         }
 
         internal LogEntry(LogLevel logLevel, EventId eventId, object state, Exception exception, string formattedMessage, string categoryName, int sequence, DateTime timestampUtc)
+            : this()
         {
             LogLevel = logLevel;
             EventId = eventId;

--- a/src/Stravaig.Extensions.Logging.Diagnostics/Render/Formatter.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/Render/Formatter.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Globalization;
-using System.Text;
 
 namespace Stravaig.Extensions.Logging.Diagnostics.Render
 {

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger(OfTCategoryType).cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger(OfTCategoryType).cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.Logging;
 using Stravaig.Extensions.Logging.Diagnostics.ExternalHelpers;
 

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger.cs
@@ -34,6 +34,9 @@ namespace Stravaig.Extensions.Logging.Diagnostics
             CategoryName = categoryName;
         }
 
+        /// <summary>
+        /// The name of the category the log entry belongs to.
+        /// </summary>
         public string CategoryName { get; }
         
         /// <summary>


### PR DESCRIPTION
# Add Property Dictionary to Log Entry

## Issue

This PR addresses Issue #89.

It adds a `PropertyDictionary` to the `EventLog` class to make it easier to access properties added to the log.

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [ ] I have updated the `readme.md` file
- [ ] I have bumped the version number in the `version.txt`
- [ ] I have added or updated any necessary tests.
- [x] I have ensured that any new code is covered by tests where reasonably possible.