### PR TITLE
(#162) Update deprecated versions of GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: sudo timedatectl set-timezone "Europe/London"
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
           echo "Is Preview: $STRAVAIG_IS_PREVIEW"
           echo "Is Stable: $STRAVAIG_IS_STABLE"
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         name: Setup .NET 6.0, 7.0 & 8.0
         with:
           dotnet-version: |
@@ -124,7 +124,7 @@ jobs:
 
       - name: Archive Simulated Release Notes
         if: ${{ env.STRAVAIG_PUBLISH_TO_NUGET == 'false' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: simulated-release-information
           path: |
@@ -135,7 +135,7 @@ jobs:
 
       - name: Archive Release Notes
         if: ${{ env.STRAVAIG_PUBLISH_TO_NUGET == 'true' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-information
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Archive Packages
         if: ${{ env.STRAVAIG_PUBLISH_TO_NUGET == 'false' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: |

--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -4,9 +4,11 @@
 
 Date: ???
 
-### Bugs
+### Bug Fixes
 
 - #160: Improve the readability of Shouldly messages by adding a `ToString` override to the LogEntry class.
 
+### Maintenance
 
+- #162: Upgrade from deprecated GitHub Actions to new versions.
 


### PR DESCRIPTION
# Update from deprecated versions of GitHub Actions

## Issue

This PR addresses Issue #162.

<!-- Fill in any additional notes about the PR here -->

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.
