### PR TITLE
#184: Test Capture Logger casting

### DIFF
--- a/Reset-WipReleaseNotes.ps1
+++ b/Reset-WipReleaseNotes.ps1
@@ -5,7 +5,7 @@ $content = @(
 "",
 "Date: ???",
 ""
-"### Bugs"
+"### Bug Fixes"
 "",
 "### Features",
 "",
@@ -15,8 +15,8 @@ $content = @(
 "",
 "- All targets:"
 "- .NET 6.0 targets:"
-"- .NET 7.0 targets:"
 "- .NET 8.0 targets:"
+"- .NET 9.0 targets:"
 "",
 "",
 ""

--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -9,8 +9,6 @@ Date: ???
 - Feature #123 changes the `TestCaptureLogger<T>` class to encapsulate an instance of `TestCaptureLogger` rather than inherit from it. If you're code relied on `TestCaptureLogger<T>` inheriting from `TestCaptureLogger` then it will likely break.
 - Feature #172 drops support for .NET 7.0. Use .NET 6.0 LTS, .NET 8.0 LTS or .NET 9.0 STS.
 
-### Bugs
-
 ### Features
 
 - #123: `TestCaptureLoggerProvider.CreateLogger<T>()`
@@ -20,6 +18,9 @@ Date: ???
   - `ITestOutputHelper.WriteLogs(ITestCaptureLogger...)`
   - `ITestOutputHelper.WriteLogs(TestCaptureLoggerProvider...)`
 - #171: Add `GetLogs(predicate)` to `TestCaptureLogger` and `TestCaptureLoggerProvider`.
+- #184: Add casting between `TestCaptureLogger` and `TestCaptureLogger<T>` to compensate for `TestCaptureLogger<T>` no longer inheriting from `TestCaptureLogger`
+  - `TestCaptureLogger<T>` may be implicitly or explicitly cast to `TestCaptureLogger`
+  - `TestCaptureLogger` must be explicitly cast to `TestCaptureLogger<T>`. The cast may fail if the category name used by the `TestCaptureLogger` does not match the type name of `T`.
 
 ### Miscellaneous
 

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestCaptureLoggerOfTTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestCaptureLoggerOfTTests.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Shouldly;
+using Stravaig.Extensions.Logging.Diagnostics.ExternalHelpers;
 
 namespace Stravaig.Extensions.Logging.Diagnostics.Tests;
 
@@ -21,6 +22,60 @@ public class TestCaptureLoggerOfTTests
         var underlyingLogger = new TestCaptureLogger("NotTheRightCategory");
         Should.Throw<InvalidOperationException>(() => new TestCaptureLogger<object>(underlyingLogger))
             .Message.ShouldBe("The category name does not match the type of this logger. Expected \"object\", got \"NotTheRightCategory\".");
+    }
+
+    [Test]
+    public void ImplicitCastCategoryMismatchThrows()
+    {
+        var underlyingLogger = new TestCaptureLogger("NotTheRightCategory");
+        Should.Throw<InvalidCastException>(() =>
+            {
+                TestCaptureLogger<object> logger = underlyingLogger; // implicit cast
+            })
+            .Message.ShouldBe("The category name does not match the type of this logger. Cannot cast a TestCaptureLogger with category name NotTheRightCategory to TestCaptureLogger<object>.");
+    }
+
+    [Test]
+    public void ExplicitCastCategoryMismatchThrows()
+    {
+        var underlyingLogger = new TestCaptureLogger("NotTheRightCategory");
+        Should.Throw<InvalidCastException>(() =>
+            {
+                _ = (TestCaptureLogger<object>)underlyingLogger; // explicit cast
+            })
+            .Message.ShouldBe("The category name does not match the type of this logger. Cannot cast a TestCaptureLogger with category name NotTheRightCategory to TestCaptureLogger<object>.");
+    }
+
+    [Test]
+    public void ConstructorCategoryCorrectNameIsConstructed()
+    {
+        var categoryName = TypeNameHelper.GetTypeDisplayName(typeof(object));
+        var underlyingLogger = new TestCaptureLogger(categoryName);
+        var typedLogger = new TestCaptureLogger<object>(underlyingLogger);
+        typedLogger.ShouldNotBeNull();
+        typedLogger.CategoryName.ShouldBe(categoryName);
+    }
+
+    [Test]
+    public void ImplicitCastCategoryCorrectNameIsConstructed()
+    {
+        var categoryName = TypeNameHelper.GetTypeDisplayName(typeof(object));
+        var underlyingLogger = new TestCaptureLogger(categoryName);
+        TestCaptureLogger<object> typedLogger = underlyingLogger;
+        typedLogger.ShouldNotBeNull();
+        typedLogger.CategoryName.ShouldBe(categoryName);
+        typedLogger.ShouldBeOfType<TestCaptureLogger<object>>();
+    }
+
+    [Test]
+    public void ExplicitCastCategoryCorrectNameIsConstructed()
+    {
+        var categoryName = TypeNameHelper.GetTypeDisplayName(typeof(object));
+        var underlyingLogger = new TestCaptureLogger(categoryName);
+        var typedLogger = (TestCaptureLogger<object>)underlyingLogger;
+        typedLogger.ShouldNotBeNull();
+        typedLogger.CategoryName.ShouldBe(categoryName);
+        typedLogger.ShouldBeOfType<TestCaptureLogger<object>>();
     }
 
     [Test]
@@ -82,5 +137,25 @@ public class TestCaptureLoggerOfTTests
         logger.GetLogs(static l => l.PropertyDictionary.ContainsKey("Location") && (string)l.PropertyDictionary["Location"] == "World")
             .Count.ShouldBe(1);
         logger.GetLogs().Count.ShouldBe(4);
+    }
+
+    [Test]
+    public void TheImplicitCastOperatorReturnsTheInternalLogger()
+    {
+        var categoryName = TypeNameHelper.GetTypeDisplayName(typeof(TestCaptureLoggerOfTTests));
+        var originalLogger = new TestCaptureLogger(categoryName);
+        var logger = new TestCaptureLogger<TestCaptureLoggerOfTTests>(originalLogger);
+        TestCaptureLogger internalLogger = logger; // implicit cast
+        internalLogger.ShouldBe(originalLogger);
+    }
+
+    [Test]
+    public void TheExplicitCastReturnsTheInternalLogger()
+    {
+        var categoryName = TypeNameHelper.GetTypeDisplayName(typeof(TestCaptureLoggerOfTTests));
+        var originalLogger = new TestCaptureLogger(categoryName);
+        var logger = new TestCaptureLogger<TestCaptureLoggerOfTTests>(originalLogger);
+        var internalLogger = (TestCaptureLogger)logger; // explicit cast
+        internalLogger.ShouldBe(originalLogger);
     }
 }

--- a/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestCaptureLoggerOfTTests.cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics.Tests/TestCaptureLoggerOfTTests.cs
@@ -25,17 +25,6 @@ public class TestCaptureLoggerOfTTests
     }
 
     [Test]
-    public void ImplicitCastCategoryMismatchThrows()
-    {
-        var underlyingLogger = new TestCaptureLogger("NotTheRightCategory");
-        Should.Throw<InvalidCastException>(() =>
-            {
-                TestCaptureLogger<object> logger = underlyingLogger; // implicit cast
-            })
-            .Message.ShouldBe("The category name does not match the type of this logger. Cannot cast a TestCaptureLogger with category name NotTheRightCategory to TestCaptureLogger<object>.");
-    }
-
-    [Test]
     public void ExplicitCastCategoryMismatchThrows()
     {
         var underlyingLogger = new TestCaptureLogger("NotTheRightCategory");
@@ -54,17 +43,6 @@ public class TestCaptureLoggerOfTTests
         var typedLogger = new TestCaptureLogger<object>(underlyingLogger);
         typedLogger.ShouldNotBeNull();
         typedLogger.CategoryName.ShouldBe(categoryName);
-    }
-
-    [Test]
-    public void ImplicitCastCategoryCorrectNameIsConstructed()
-    {
-        var categoryName = TypeNameHelper.GetTypeDisplayName(typeof(object));
-        var underlyingLogger = new TestCaptureLogger(categoryName);
-        TestCaptureLogger<object> typedLogger = underlyingLogger;
-        typedLogger.ShouldNotBeNull();
-        typedLogger.CategoryName.ShouldBe(categoryName);
-        typedLogger.ShouldBeOfType<TestCaptureLogger<object>>();
     }
 
     [Test]

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger(OfTCategoryType).cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger(OfTCategoryType).cs
@@ -36,6 +36,41 @@ public class TestCaptureLogger<TCategoryType> : ITestCaptureLogger, ILogger<TCat
         _logger = logger;
     }
 
+    /// <summary>
+    /// Converts a <see cref="TestCaptureLogger{TCategoryType}"/> instance to a <see cref="TestCaptureLogger"/> instance.
+    /// </summary>
+    /// <param name="logger">The <see cref="TestCaptureLogger{TCategoryType}"/> instance to convert.</param>
+    /// <returns>A <see cref="TestCaptureLogger"/> instance.</returns>
+    public static implicit operator TestCaptureLogger(TestCaptureLogger<TCategoryType> logger)
+    {
+        return logger._logger;
+    }
+
+    /// <summary>
+    /// Defines an implicit conversion from a non-generic <see cref="TestCaptureLogger"/>
+    /// to a generic <see cref="TestCaptureLogger{TCategoryType}"/>.
+    /// </summary>
+    /// <param name="logger">The instance of the non-generic <see cref="TestCaptureLogger"/> to convert.</param>
+    /// <returns>
+    /// A new instance of <see cref="TestCaptureLogger{TCategoryType}"/> if the category name
+    /// of the provided logger matches the type of the category.
+    /// </returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown if the category name of the provided logger does not match the expected
+    /// category name for the specified <typeparamref name="TCategoryType"/>.
+    /// </exception>
+    public static implicit operator TestCaptureLogger<TCategoryType>(TestCaptureLogger logger)
+    {
+        // Check the category name to see if it matches or can be used for this type
+        var expectedCategoryName = TypeNameHelper.GetTypeDisplayName(typeof(TCategoryType));
+        if (logger.CategoryName != expectedCategoryName)
+            throw new InvalidCastException(
+                $"The category name does not match the type of this logger. Cannot cast a TestCaptureLogger with category name {logger.CategoryName} to TestCaptureLogger<{expectedCategoryName}>.");
+
+        // Return a new generic logger using the existing logger
+        return new TestCaptureLogger<TCategoryType>(logger);
+    }
+
     /// <inheritdoc />
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         => _logger.Log(logLevel, eventId, state, exception, formatter);

--- a/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger(OfTCategoryType).cs
+++ b/src/Stravaig.Extensions.Logging.Diagnostics/TestCaptureLogger(OfTCategoryType).cs
@@ -47,7 +47,7 @@ public class TestCaptureLogger<TCategoryType> : ITestCaptureLogger, ILogger<TCat
     }
 
     /// <summary>
-    /// Defines an implicit conversion from a non-generic <see cref="TestCaptureLogger"/>
+    /// Defines an explicit conversion from a non-generic <see cref="TestCaptureLogger"/>
     /// to a generic <see cref="TestCaptureLogger{TCategoryType}"/>.
     /// </summary>
     /// <param name="logger">The instance of the non-generic <see cref="TestCaptureLogger"/> to convert.</param>
@@ -59,7 +59,7 @@ public class TestCaptureLogger<TCategoryType> : ITestCaptureLogger, ILogger<TCat
     /// Thrown if the category name of the provided logger does not match the expected
     /// category name for the specified <typeparamref name="TCategoryType"/>.
     /// </exception>
-    public static implicit operator TestCaptureLogger<TCategoryType>(TestCaptureLogger logger)
+    public static explicit operator TestCaptureLogger<TCategoryType>(TestCaptureLogger logger)
     {
         // Check the category name to see if it matches or can be used for this type
         var expectedCategoryName = TypeNameHelper.GetTypeDisplayName(typeof(TCategoryType));


### PR DESCRIPTION
# Test Capture Logger Casting

## Issue

This PR addresses Issue #184 .

Because `TestCaptureLogger<T>` no longer inherits from `TestCaptureLogger` any code that assumed that it could reference a `TestCaptureLogger<T>` as a `TestCaptureLogger` fails. This can be worked around by adding an implicit cast to cast to the former base class, and an explicit cast to convert the other way around. The code should now function as it previously did.

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!--
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [x] I have updated the repo `readme.md` file.
- [x] I have updated the package `readme.md` file.
- [x] I have updated the documentation in the docs folder.
- [x] I have bumped the version number in the `version.txt`.
- [x] I have added or updated any necessary tests.
- [x] I have ensured that any new code is covered by tests where reasonably possible.
