### PR TITLE
Fix the timestamps in LogEntry

### DIFF
--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -6,9 +6,7 @@ Date: ???
 
 ### Bug Fixes
 
-### Features
-
-### Miscellaneous
+- #190: Fix issue with timestamps being out of order.
 
 ### Dependencies
 


### PR DESCRIPTION
# Fix timestamps in the LogEntry

## Issue

This PR addresses Issue #190.

In rare cases when many logs are created in multiple threads the timestamps and Sequence numbers can become out of order. Each should only ever increase, and ordering a set of log entries by sequence should produce the same sequence as ordering by timestamp.

This fix, ensures that timestamps are only ever increasing. The resolution of the `DateTime.UtcNow` function is system dependent, so can be between [0.5ms to 15ms](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.utcnow?view=net-9.0#:~:text=The%20resolution%20of%20this%20property%20depends%20on%20the%20system%20timer%2C%20which%20depends%20on%20the%20underlying%20operating%20system.%20It%20tends%20to%20be%20between%200.5%20and%2015%20milliseconds.), or 5000 to 150,000 ticks ([at 10,000 ticks per millisecond](https://learn.microsoft.com/en-us/dotnet/api/system.timespan.tickspermillisecond?view=net-9.0)). So, in some scenarios, multiple log entries can be created before the `DateTime.UtcNow` method produces a new value. In this event a new `DateTime` is produces that increments the Ticks by 1 to ensure that the value is distinct from the preceding log entry.

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!--
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [x] I have updated the repo `readme.md` file.
- [ ] I have updated the package `readme.md` file.
- [ ] I have updated the documentation in the docs folder.
- [ ] I have bumped the version number in the `version.txt`.
- [ ] I have added or updated any necessary tests.
- [ ] I have ensured that any new code is covered by tests where reasonably possible.
